### PR TITLE
pass commandline args through to WebView2

### DIFF
--- a/Photino.Native/Photino.Windows.cpp
+++ b/Photino.Native/Photino.Windows.cpp
@@ -746,7 +746,10 @@ void Photino::AttachWebView()
 	size_t runtimePathLen = wcsnlen(_webview2RuntimePath, _countof(_webview2RuntimePath));
 	PCWSTR runtimePath = runtimePathLen > 0 ? &_webview2RuntimePath[0] : nullptr;
 
-	HRESULT envResult = CreateCoreWebView2EnvironmentWithOptions(runtimePath, _temporaryFilesPath, nullptr,
+    auto options = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
+    options->put_AdditionalBrowserArguments(GetCommandLineW());
+
+    HRESULT envResult = CreateCoreWebView2EnvironmentWithOptions(runtimePath, _temporaryFilesPath, options.Get(),
 		Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
 			[&](HRESULT result, ICoreWebView2Environment* env) -> HRESULT {
 				if (result != S_OK) { return result; }

--- a/Photino.Native/Photino.h
+++ b/Photino.Native/Photino.h
@@ -12,6 +12,7 @@
 #include <Windows.h>
 #include <wil/com.h>
 #include <WebView2.h>
+#include <WebView2EnvironmentOptions.h>
 typedef wchar_t *AutoString;
 class WinToastHandler;
 #else


### PR DESCRIPTION
- to easily configure WebView2 browser features
- came up due to the need to disable gpu support when troubleshooting a black screen user issue